### PR TITLE
adjust power requirements to 100mA

### DIFF
--- a/src/usb_desc.c
+++ b/src/usb_desc.c
@@ -47,7 +47,7 @@ __code const configuration_descriptor_t configuration_descriptor =
   .bConfigurationValue    = 1,     // Configuration identifer
   .iConfiguration         = 0,
   .bmAttributes           = 0x80,  // Bus powered
-  .bMaxPower              = 100,   // Max power of 100*2mA = 200mA 
+  .bMaxPower              = 50,   // Max power of 50*2mA = 100mA 
   .interface_descriptor = 
     {
       .bLength            = 9,    // Size of the interface descriptor 


### PR DESCRIPTION
on mac, it complained that 200mA wasnt available. 100mA should be more than enough for most of these dongles. (not sure about current requirements of Crazyradio PA)

I'm using cheap no-brand nrf24lu1p dongle (16k flash) from aliexpress. (preparing more PR's to handle the bootloader code for 16k flash as well.)
