### PR TITLE
support generic 16k dongles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 SDCC ?= sdcc
-CFLAGS = --model-large --std-c99
+FLASH_SIZE ?= 32
+ifeq ($(FLASH_SIZE), 16)
+    CFLAGS = --model-large --std-sdcc99 -DFLASH_SIZE_16K
+else
+    CFLAGS = --model-large --std-sdcc99
+endif
 LDFLAGS = --xram-loc 0x8000 --xram-size 2048 --model-large
 VPATH = src/
 OBJS = main.rel usb.rel usb_desc.rel radio.rel
+
 
 SDCC_VER := $(shell $(SDCC) -v | grep -Po "\d\.\d\.\d" | sed "s/\.//g")
 

--- a/readme.md
+++ b/readme.md
@@ -26,11 +26,17 @@ The following hardware has been tested and is known to work.
 - CrazyRadio PA USB dongle
 - SparkFun nRF24LU1+ breakout board
 - Logitech Unifying dongle (model C-U0007, Nordic Semiconductor based)
+- generic nrf24lu1p dongles from aliexpress (16k flash w/ Nordic bootloader)
 
 ## Build the firmware
 
 ```
 make
+```
+
+for 16k flash dongles:
+```
+make FLASH_SIZE=16
 ```
 
 ## Flash over USB

--- a/src/usb.h
+++ b/src/usb.h
@@ -19,8 +19,14 @@
 #include "nRF24LU1P.h"
 #include "usb_desc.h"
 
+#ifdef  FLASH_SIZE_16K
+#define NORDIC_BOOTLOADER_START_ADDR  0x3800
+#else
+#define NORDIC_BOOTLOADER_START_ADDR  0x7800
+#endif
+
 // Nordic nootloader entry point
-static void (*nordic_bootloader)() = (void (*)())0x7800;
+static void (*nordic_bootloader)() = (void (*)()) NORDIC_BOOTLOADER_START_ADDR;
 
 // Logitech nootloader entry point
 static void (*logitech_bootloader)() = (void (*)())0x7400;


### PR DESCRIPTION
adds support for generic 16k dongles, addresses issue: https://github.com/BastilleResearch/mousejack/issues/1
